### PR TITLE
Supply chain security - SHA pins, cosign signing, SBOM, SLSA provenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -6,8 +6,9 @@ on:
     tags: ['v*']
 
 permissions:
-  contents: read
+  contents: write
   packages: write
+  id-token: write
 
 jobs:
   build-push:
@@ -15,16 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -32,7 +33,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/portager
           tags: |
@@ -42,7 +43,8 @@ jobs:
             type=sha,format=short
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        id: build-push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -51,6 +53,56 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+
+      - name: Sign container image
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          DIGEST: ${{ steps.build-push.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes ${images}
+
+      - name: Generate SBOM (SPDX)
+        uses: anchore/sbom-action@17ae1740179002c89186b61233e0f892c3118b11 # v0.23.0
+        with:
+          image: ghcr.io/${{ github.repository_owner }}/portager@${{ steps.build-push.outputs.digest }}
+          format: spdx-json
+          output-file: sbom-spdx.json
+
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@17ae1740179002c89186b61233e0f892c3118b11 # v0.23.0
+        with:
+          image: ghcr.io/${{ github.repository_owner }}/portager@${{ steps.build-push.outputs.digest }}
+          format: cyclonedx-json
+          output-file: sbom-cyclonedx.json
+
+      - name: Attach SBOM attestations to image
+        env:
+          DIGEST: ${{ steps.build-push.outputs.digest }}
+        run: |
+          cosign attest --yes --type spdxjson \
+            --predicate sbom-spdx.json \
+            "ghcr.io/${{ github.repository_owner }}/portager@${DIGEST}"
+          cosign attest --yes --type cyclonedx \
+            --predicate sbom-cyclonedx.json \
+            "ghcr.io/${{ github.repository_owner }}/portager@${DIGEST}"
+
+      - name: Upload SBOMs to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release create "${TAG}" --generate-notes || true
+          gh release upload "${TAG}" sbom-spdx.json sbom-cyclonedx.json --clobber
 
       - name: Package and push Helm chart
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build image for scanning
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           push: false
@@ -33,7 +33,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
         with:
           image-ref: 'portager:scan'
           format: 'sarif'
@@ -41,13 +41,13 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ae9ef3a1d2e3413523c3741725c30064970cc0d4 # v3.32.5
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
 
       - name: Run Trivy (table output for PR comments)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
         with:
           image-ref: 'portager:scan'
           format: 'table'

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ bin/
 .DS_Store
 
 docs/spec.md
+docs/CODE_WALKTHROUGH.md
+docs/SECURITY_POSTURE.md
+docs/ROADMAP.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,14 +14,15 @@ Portager is a Kubernetes operator that declaratively syncs container images betw
 
 **Version:** v0.1.0 (released)
 
-### Implemented (Phases 0-4, 6)
+### Implemented (Phases 0-4, 6 + Tier 1)
 - CRD types, reconciler, full sync loop
 - Secret-based auth, anonymous auth, ECR auth (IRSA)
 - Digest comparison, per-image status, Kubernetes Events
 - Cron scheduling with RequeueAfter, sync-now annotation
 - ECR repo auto-creation
 - Prometheus metrics, Helm chart, leader election
-- CI: unit tests, e2e tests, multi-arch build + push, Helm OCI publish
+- CI: unit tests, e2e tests, multi-arch build + push, Helm OCI publish, Trivy scanning
+- Supply chain security: all GitHub Actions pinned to commit SHAs, cosign keyless image signing on tagged releases, SBOM generation (SPDX + CycloneDX) attached as OCI attestations, SLSA provenance via `provenance: mode=max`, Dependabot for automated dependency updates
 
 ### Not Implemented
 
@@ -112,10 +113,12 @@ make helm-template    # Render Helm templates locally
 │   ├── CONFIGURATION.md           # Helm values, auth strategies, spec reference
 │   ├── DEPLOY_README.md           # Deployment walkthroughs (EKS, non-EKS, etc.)
 │   └── spec.md                    # Original design spec (historical)
+├── .github/dependabot.yml         # Automated dependency updates (actions, gomod, docker)
 └── .github/workflows/
     ├── test.yml                   # Unit/integration CI
     ├── test-e2e.yml               # E2E CI (Kind cluster)
-    └── build-push.yml             # Build + push image and Helm chart to GHCR
+    ├── build-push.yml             # Build + push + sign + SBOM + provenance
+    └── trivy.yml                  # Container vulnerability scanning (SARIF → GitHub Security)
 ```
 
 ## Key Dependencies
@@ -221,9 +224,12 @@ make cleanup-test-e2e # Delete Kind cluster
 
 ## CI/CD
 
+All GitHub Actions are pinned to full commit SHAs (not floating tags) for supply chain security. Dependabot (`.github/dependabot.yml`) proposes weekly PRs for action, Go module, and Docker base image updates.
+
 - **test.yml** — Runs `make test` on push/PR
 - **test-e2e.yml** — Spins up Kind, runs `make test-e2e` on push/PR
-- **build-push.yml** — Builds multi-arch image (amd64/arm64) and pushes to GHCR. On `v*` tags, also publishes the Helm chart as an OCI artifact to `oci://ghcr.io/jarodr47/portager/charts`
+- **build-push.yml** — Builds multi-arch image (amd64/arm64) and pushes to GHCR. On every push: generates SPDX + CycloneDX SBOMs and attaches them as OCI attestations via cosign. On `v*` tags: signs images with cosign (keyless via Fulcio + Rekor), uploads SBOMs to GitHub Release, and publishes the Helm chart to `oci://ghcr.io/jarodr47/portager/charts`. SLSA provenance is attached via `docker/build-push-action` with `provenance: mode=max`.
+- **trivy.yml** — Builds image locally and runs Trivy vulnerability scanner. Uploads SARIF to GitHub Security tab and fails on CRITICAL/HIGH findings.
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references (19 `uses:` lines across 4 workflows) to full commit SHAs with version comments
- Add cosign keyless image signing on tagged releases (Fulcio + Rekor via GitHub OIDC)
- Add SBOM generation in SPDX and CycloneDX formats, attached as OCI attestations to every pushed image
- Enable SLSA provenance attestation via `provenance: mode=max` on docker/build-push-action
- Upload SBOMs as GitHub Release assets on tagged releases
- Add Dependabot config for github-actions, gomod, and docker (weekly)

## Test plan

- [x] Push to a branch and verify test.yml, test-e2e.yml, and trivy.yml workflows pass with SHA-pinned actions
- [x] Push to main and verify build-push.yml builds, pushes image, generates SBOMs, and attaches attestations
- [ ] Push a `v*` tag and verify cosign signing, SBOM release upload, and Helm chart push all succeed
- [x] Run `cosign verify --certificate-identity-regexp=github ghcr.io/jarodr47/portager:<tag>` to verify image signature
- [x] Run `cosign verify-attestation --type spdxjson ghcr.io/jarodr47/portager:<tag>` to verify SBOM attestation
- [ ] Verify Dependabot opens PRs within a week for any outdated dependencies