### PR TITLE
Helm chart hardening

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -29,6 +29,21 @@ For deployment walkthroughs, see the [Deploy Guide](DEPLOY_README.md). For a pro
 | `aws.credentials.secretAccessKey` | `""` | AWS secret access key |
 | `aws.credentials.region` | `us-east-1` | AWS region |
 | `aws.existingSecret` | `""` | Name of an existing Secret containing AWS credentials |
+| `nodeSelector` | `{}` | Node selector for pod scheduling |
+| `tolerations` | `[]` | Tolerations for pod scheduling |
+| `affinity` | `{}` | Affinity rules for pod scheduling |
+| `topologySpreadConstraints` | `[]` | Topology spread constraints for pod scheduling |
+| `priorityClassName` | `""` | Priority class name for the controller pod |
+| `podAnnotations` | `{}` | Annotations added to controller pod metadata |
+| `podLabels` | `{}` | Labels added to controller pod metadata |
+| `imagePullSecrets` | `[]` | Image pull secrets for the controller pod |
+| `extraEnv` | `[]` | Additional environment variables for the controller container |
+| `extraVolumes` | `[]` | Additional volumes for the controller pod |
+| `extraVolumeMounts` | `[]` | Additional volume mounts for the controller container |
+| `podDisruptionBudget.enabled` | `false` | Enable PodDisruptionBudget for the controller |
+| `podDisruptionBudget.minAvailable` | `1` | Minimum available pods during disruption |
+| `startupProbe.enabled` | `false` | Enable startup probe (httpGet /healthz:8081, 5min budget) |
+| `terminationGracePeriodSeconds` | `10` | Termination grace period for the controller pod |
 
 ---
 

--- a/helm/portager/templates/deployment.yaml
+++ b/helm/portager/templates/deployment.yaml
@@ -12,15 +12,29 @@ spec:
       {{- include "portager.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "portager.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "portager.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       containers:
         - name: manager
           image: {{ include "portager.image" . }}
@@ -50,14 +64,19 @@ spec:
             - secretRef:
                 name: {{ .Values.aws.existingSecret }}
           {{- end }}
-          {{- if .Values.aws.credentials.enabled }}
+          {{- if or .Values.aws.credentials.enabled .Values.extraEnv }}
           env:
+            {{- if .Values.aws.credentials.enabled }}
             - name: AWS_ACCESS_KEY_ID
               value: {{ .Values.aws.credentials.accessKeyId | quote }}
             - name: AWS_SECRET_ACCESS_KEY
               value: {{ .Values.aws.credentials.secretAccessKey | quote }}
             - name: AWS_REGION
               value: {{ .Values.aws.credentials.region | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -65,6 +84,14 @@ spec:
             capabilities:
               drop:
                 - ALL
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            failureThreshold: 30
+            periodSeconds: 10
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -79,3 +106,27 @@ spec:
             periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/portager/templates/pdb.yaml
+++ b/helm/portager/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "portager.fullname" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "portager.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "portager.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/portager/values.yaml
+++ b/helm/portager/values.yaml
@@ -37,3 +37,70 @@ aws:
     region: "us-east-1"
   # Reference an existing Secret containing AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION
   existingSecret: ""
+
+# -- Scheduling
+
+nodeSelector: {}
+  # disktype: ssd
+
+tolerations: []
+  # - key: "dedicated"
+  #   operator: "Equal"
+  #   value: "portager"
+  #   effect: "NoSchedule"
+
+affinity: {}
+  # podAntiAffinity:
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #     - labelSelector:
+  #         matchExpressions:
+  #           - key: app.kubernetes.io/name
+  #             operator: In
+  #             values:
+  #               - portager
+  #       topologyKey: kubernetes.io/hostname
+
+topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       app.kubernetes.io/name: portager
+
+priorityClassName: ""
+  # Recommended for production: system-cluster-critical
+
+# -- Pod metadata and pull secrets
+
+podAnnotations: {}
+
+podLabels: {}
+
+imagePullSecrets: []
+  # - name: my-registry-secret
+
+# -- Extra container and volume configuration
+
+extraEnv: []
+  # - name: MY_VAR
+  #   value: my-value
+
+extraVolumes: []
+  # - name: tmp
+  #   emptyDir: {}
+
+extraVolumeMounts: []
+  # - name: tmp
+  #   mountPath: /tmp
+
+# -- Disruption and probes
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+startupProbe:
+  enabled: false
+
+terminationGracePeriodSeconds: 10


### PR DESCRIPTION
## Summary
- Add PodDisruptionBudget template for safe node drain handling
- Add scheduling values (nodeSelector, tolerations, affinity, topologySpreadConstraints, priorityClassName) for production pod placement
- Add extensibility values (extraEnv, extraVolumes, extraVolumeMounts, podAnnotations, podLabels, imagePullSecrets) for platform team customization
- Add optional startup probe with 5-minute budget for large clusters
- Make terminationGracePeriodSeconds configurable

## Test plan
- [x] `make helm-lint` passes
- [x] `make helm-template` renders correctly with defaults (no new features visible)
- [x] Each new value renders correctly when set individually
- [x] Combined values render correctly together