### PR TITLE
Add semver filtering and status columns to kubectl output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Portager is a Kubernetes operator that declaratively syncs container images betw
 
 ## Current Status
 
-**Version:** v0.2.1 (released)
+**Version:** v0.3.0
 
 ### Implemented (Phases 0-4, 6 + Tier 1 + CR.1)
 - CRD types, reconciler, full sync loop
@@ -24,6 +24,7 @@ Portager is a Kubernetes operator that declaratively syncs container images betw
 - CI: unit tests, e2e tests, multi-arch build + push, Helm OCI publish, Trivy scanning
 - Supply chain security: all GitHub Actions pinned to commit SHAs, cosign keyless image signing on tagged releases, SBOM generation (SPDX + CycloneDX) attached as OCI attestations, SLSA provenance via `provenance: mode=max`, Dependabot for automated dependency updates
 - Pre-sync validation gates: cosign signature verification (key-based and keyless), vulnerability severity gating via OCI attestation SARIF reports, SBOM existence gate (SPDX + CycloneDX)
+- Semver tag filtering: auto-discover tags matching semver constraints (wildcards, ranges, tilde, caret) with configurable maxTags limit
 
 ### Not Implemented
 
@@ -66,7 +67,6 @@ spec:
 - Key library: `go-containerregistry` has `v1.ImageIndex` and `v1.Platform` types for manifest list manipulation
 
 #### Phase 7 (Stretch Features)
-- **Semver tag filtering** — allow patterns like `semver: >=1.22.0 <1.23.0` that auto-discover matching tags from the source registry
 - **Webhook triggers** — endpoint for registries to call on new image push, triggering immediate sync
 - **ImageSyncPolicy** — cluster-scoped CRD for governance: org-wide defaults (destination, platforms, schedule) and policy controls (allow/deny registries, image name patterns, tag restrictions like blocking `latest`)
 - **Dry-run mode** — `spec.dryRun: true` evaluates what would sync without copying
@@ -106,13 +106,15 @@ make helm-template    # Render Helm templates locally
 │   ├── schedule/                  # Cron parsing via robfig/cron/v3
 │   ├── sync/                      # Image copy via go-containerregistry (crane)
 │   │   └── copier.go              #   ImageCopier with staticKeychain
+│   ├── tags/                      # Semver tag filtering
+│   │   └── resolver.go            #   TagLister, SemverResolver (Masterminds/semver)
 │   └── verify/                    # Pre-sync validation gates
 │       ├── verifier.go            #   Validator, CosignVerifier, VulnerabilityChecker, SbomChecker interfaces
 │       ├── cosign.go              #   Cosign signature verification (key-based + keyless)
 │       ├── vulnerability.go       #   SARIF-based vulnerability severity gating
 │       └── sbom.go                #   SBOM existence gate (SPDX + CycloneDX)
 ├── config/                        # Kustomize manifests (CRDs, RBAC, manager)
-├── helm/portager/                 # Helm chart (v0.2.1)
+├── helm/portager/                 # Helm chart (v0.3.0)
 ├── test/e2e/                      # E2E tests (Kind + Ginkgo)
 ├── docs/
 │   ├── CONFIGURATION.md           # Helm values, auth strategies, spec reference
@@ -135,6 +137,7 @@ make helm-template    # Render Helm templates locally
 | go-containerregistry | 0.21.1 | OCI image operations (crane) |
 | aws-sdk-go-v2 | latest | ECR auth + repo creation |
 | robfig/cron/v3 | 3.0.1 | Cron expression parsing |
+| Masterminds/semver/v3 | 3.4.0 | Semver constraint parsing and matching |
 | sigstore/cosign/v2 | 2.6.2 | Cosign signature verification |
 | Ginkgo v2 / Gomega | 2.27+ | Testing framework |
 | Kubebuilder | 4.12.0 | Scaffolding (go.kubebuilder.io/v4) |
@@ -165,15 +168,17 @@ Reconcile(ImageSync) →
   5. Check if due based on nextSyncTime → requeue if not (only when spec unchanged)
   6. Build source/dest authenticators (anonymous, secret, or ECR)
   7. If createDestinationRepos + ECR → ensure repos exist
-  8. For each image+tag:
+  8. For each image:
+     - If semver set → list tags from source, filter by constraint, merge with explicit tags
+  9. For each image+tag:
      a. GetDigest on source (HTTP HEAD, no layer download)
      b. GetDigest on destination (may fail if not pushed yet)
      c. If digests match → skip, emit ImageSkipped event
      d. If validation configured → run cosign/vulnerability gates, emit ImageVerified or ValidationFailed
      e. If different/missing → crane.Copy, emit ImageSynced or SyncFailed
-  9. Update .status (conditions, per-image results, summary counts, observedGeneration)
- 10. Emit SyncComplete event
- 11. Requeue after next schedule interval
+ 10. Update .status (conditions, per-image results, summary counts, observedGeneration)
+ 11. Emit SyncComplete event
+ 12. Requeue after next schedule interval
 ```
 
 ### Key Design Patterns
@@ -199,7 +204,7 @@ ImageSyncStatus
 
 ### Events Emitted
 
-`RepoEnsured`, `ImageSynced`, `ImageSkipped`, `ImageVerified`, `ValidationFailed`, `SyncFailed`, `SyncComplete`
+`RepoEnsured`, `TagsResolved`, `TagResolutionFailed`, `ImageSynced`, `ImageSkipped`, `ImageVerified`, `ValidationFailed`, `SyncFailed`, `SyncComplete`
 
 ### Prometheus Metrics
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Portager fills this gap with a Kubernetes-native, GitOps-friendly approach that 
 - **Registry-agnostic** — Works with Docker Hub, GHCR, Quay, Chainguard, ECR, GCR, Harbor, Nexus, and any OCI-compliant registry
 - **Pluggable auth** — Kubernetes Secrets (`dockerconfigjson`), ECR via IRSA, or anonymous for public registries
 - **Cron scheduling** — Standard cron expressions, shorthands like `@every 6h`, and on-demand sync via annotation
+- **Semver tag filtering** — Auto-discover tags matching semver constraints like `1.x`, `~1.22.0`, or `^22.0.0` instead of listing every tag
+- **Pre-sync validation** — Optional cosign signature verification, vulnerability severity gating (SARIF), and SBOM existence checks before copying
 - **Observable** — Per-image status on the resource, Kubernetes Events, and custom Prometheus metrics
 
 ## Installation
@@ -76,7 +78,7 @@ Portager fills this gap with a Kubernetes-native, GitOps-friendly approach that 
 
 ```bash
 helm install portager oci://ghcr.io/jarodr47/portager/charts/portager \
-  --version 0.2.1 -n portager-system --create-namespace
+  --version 0.3.0 -n portager-system --create-namespace
 ```
 
 <details>
@@ -121,7 +123,8 @@ spec:
     - name: alpine
       tags: ["3.21", "latest"]
     - name: nginx
-      tags: ["1.27", "latest"]
+      tags: ["latest"]
+      semver: "~1.27.0"          # auto-sync newest 1.27.x patch releases
 ```
 
 ```bash

--- a/api/v1alpha1/imagesync_types.go
+++ b/api/v1alpha1/imagesync_types.go
@@ -84,9 +84,24 @@ type ImageSpec struct {
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 
-	// tags is the list of image tags to sync (e.g., ["latest", "1.22"]).
-	// +kubebuilder:validation:MinItems=1
-	Tags []string `json:"tags"`
+	// tags is the list of explicit image tags to sync (e.g., ["latest", "1.22"]).
+	// At least one of tags or semver must be specified.
+	// +optional
+	Tags []string `json:"tags,omitempty"`
+
+	// semver is a semver constraint string for auto-discovering tags from the
+	// source registry. Supports wildcards (1.x, 1.3.x), ranges (>=1.22.0 <1.23.0),
+	// tilde (~1.3.0), and caret (^1.3.0) syntax. Non-semver tags in the registry
+	// are silently skipped. Resolved tags are sorted by version descending (newest first).
+	// +optional
+	Semver string `json:"semver,omitempty"`
+
+	// maxTags limits how many semver-matched tags are synced (newest first).
+	// Only applies when semver is set. 0 means unlimited.
+	// +kubebuilder:default=10
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	MaxTags int `json:"maxTags,omitempty"`
 }
 
 // ImageSyncSpec defines the desired state of ImageSync — which images to sync,
@@ -258,6 +273,11 @@ type ImageSyncStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
+// +kubebuilder:printcolumn:name="Synced",type=integer,JSONPath=`.status.syncedImages`
+// +kubebuilder:printcolumn:name="Failed",type=integer,JSONPath=`.status.failedImages`
+// +kubebuilder:printcolumn:name="Schedule",type=string,JSONPath=`.spec.schedule`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // ImageSync is the Schema for the imagesyncs API
 type ImageSync struct {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,6 +38,7 @@ import (
 	portagerv1alpha1 "github.com/jarodr47/portager/api/v1alpha1"
 	"github.com/jarodr47/portager/internal/controller"
 	"github.com/jarodr47/portager/internal/controller/schedule"
+	"github.com/jarodr47/portager/internal/controller/tags"
 	"github.com/jarodr47/portager/internal/controller/verify"
 	// +kubebuilder:scaffold:imports
 )
@@ -189,6 +190,9 @@ func main() {
 			CosignVerifier:       verify.NewCosignVerifier(),
 			VulnerabilityChecker: verify.NewVulnerabilityChecker(),
 			SbomChecker:          verify.NewSbomChecker(),
+		},
+		TagResolver: &tags.SemverResolver{
+			Lister: &tags.CraneTagLister{},
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "ImageSync")

--- a/config/crd/bases/portager.portager.io_imagesyncs.yaml
+++ b/config/crd/bases/portager.portager.io_imagesyncs.yaml
@@ -14,7 +14,23 @@ spec:
     singular: imagesync
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Status
+      type: string
+    - jsonPath: .status.syncedImages
+      name: Synced
+      type: integer
+    - jsonPath: .status.failedImages
+      name: Failed
+      type: integer
+    - jsonPath: .spec.schedule
+      name: Schedule
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ImageSync is the Schema for the imagesyncs API
@@ -99,21 +115,34 @@ spec:
                   description: ImageSpec defines a single image to sync, including
                     which tags to copy.
                   properties:
+                    maxTags:
+                      default: 10
+                      description: |-
+                        maxTags limits how many semver-matched tags are synced (newest first).
+                        Only applies when semver is set. 0 means unlimited.
+                      minimum: 0
+                      type: integer
                     name:
                       description: |-
                         name is the image name relative to the source registry
                         (e.g., "go", "node", "python").
                       type: string
+                    semver:
+                      description: |-
+                        semver is a semver constraint string for auto-discovering tags from the
+                        source registry. Supports wildcards (1.x, 1.3.x), ranges (>=1.22.0 <1.23.0),
+                        tilde (~1.3.0), and caret (^1.3.0) syntax. Non-semver tags in the registry
+                        are silently skipped. Resolved tags are sorted by version descending (newest first).
+                      type: string
                     tags:
-                      description: tags is the list of image tags to sync (e.g., ["latest",
-                        "1.22"]).
+                      description: |-
+                        tags is the list of explicit image tags to sync (e.g., ["latest", "1.22"]).
+                        At least one of tags or semver must be specified.
                       items:
                         type: string
-                      minItems: 1
                       type: array
                   required:
                   - name
-                  - tags
                   type: object
                 minItems: 1
                 type: array

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -174,9 +174,13 @@ spec:
       enabled: true                # Require SBOM (SPDX or CycloneDX) attached
   images:
     - name: go
-      tags: ["latest", "1.22"]
+      tags: ["latest", "1.22"]     # Explicit tags
     - name: python
-      tags: ["latest", "3.12"]
+      semver: "3.12.x"             # Auto-discover matching semver tags
+      maxTags: 10                   # Limit to 10 newest matches (default)
+    - name: node
+      tags: ["lts"]                # Explicit + semver together
+      semver: "^22.0.0"
 ```
 
 ### Schedule Examples
@@ -200,6 +204,72 @@ kubectl annotate imagesync <name> portager.portager.io/sync-now=true
 ```
 
 The controller removes the annotation after processing.
+
+---
+
+## Semver Tag Filtering
+
+Instead of listing every tag explicitly, you can use a semver constraint to auto-discover matching tags from the source registry. On each reconcile, the controller lists all tags, parses them as semver versions, filters by the constraint, and syncs the newest matches.
+
+### Constraint Syntax
+
+Portager uses [Masterminds/semver](https://github.com/Masterminds/semver) constraint syntax:
+
+| Pattern | Meaning | Example Matches |
+|---|---|---|
+| `1.x` | Any 1.y.z | 1.0, 1.5.3, 1.99 |
+| `1.3.x` | Any 1.3.z | 1.3.0, 1.3.7 |
+| `>= 1.22.0, < 1.23.0` | Range | 1.22.0, 1.22.5 |
+| `~1.3.0` | Tilde (patch-level) | >= 1.3.0, < 1.4.0 |
+| `^1.3.0` | Caret (minor-level) | >= 1.3.0, < 2.0.0 |
+
+### Examples
+
+```yaml
+# Sync the 10 newest 1.x versions of alpine
+images:
+  - name: alpine
+    semver: "1.x"
+
+# Sync Go 1.22 patch releases + latest
+images:
+  - name: go
+    tags: ["latest"]
+    semver: "~1.22.0"
+
+# Sync all Python 3.12.x versions (unlimited)
+images:
+  - name: python
+    semver: "3.12.x"
+    maxTags: 0
+```
+
+### Fields
+
+| Field | Default | Description |
+|---|---|---|
+| `semver` | — | Semver constraint string. When set, the controller lists tags from the source registry and syncs those matching the constraint. |
+| `maxTags` | `10` | Maximum number of semver-matched tags to sync (newest first). Set to `0` for unlimited. Only applies when `semver` is set. |
+
+### Behavior
+
+- **Explicit tags (`tags`) and `semver` can be used together.** The controller merges both lists, deduplicating. Explicit tags are synced first, then semver-resolved tags.
+- **At least one of `tags` or `semver` must be specified** per image. The controller rejects the ImageSync with an `InvalidSpec` condition if neither is provided.
+- **Non-semver tags are silently skipped.** Tags like `latest`, `alpine`, or `bullseye` are not valid semver and won't match any constraint. Use explicit `tags` for these.
+- **Tags with pre-release suffixes** (e.g., `1.22.1-rc.1`) only match constraints that explicitly include pre-release identifiers.
+- **`v` prefixes are handled automatically** — `v1.22.0` is treated as `1.22.0` for matching but synced under its original tag string.
+- **Resolved tags appear in `.status.images[].tags[]`** just like explicit tags, with full digest and sync status tracking.
+
+### Events
+
+| Event | Type | When |
+|---|---|---|
+| `TagsResolved` | Normal | Semver constraint resolved N tags for an image |
+| `TagResolutionFailed` | Warning | Failed to list tags or parse constraint |
+
+### Rate Limiting Note
+
+Each reconcile calls the registry's tag listing API once per image with a `semver` constraint. For registries with rate limits (e.g., Docker Hub), keep this in mind when setting short cron schedules.
 
 ---
 

--- a/docs/DEPLOY_README.md
+++ b/docs/DEPLOY_README.md
@@ -96,6 +96,9 @@ spec:
       tags: ["latest", "3.21"]
     - name: busybox
       tags: ["latest"]
+    # Semver tag filtering: auto-discover matching versions
+    - name: node
+      semver: "^22.0.0"           # Sync the 10 newest Node 22.x releases
 ```
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jarodr47/portager
 go 1.25.7
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.56.1
 	github.com/google/go-containerregistry v0.21.3
@@ -21,7 +22,6 @@ require (
 require (
 	cel.dev/expr v0.25.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.4 // indirect

--- a/helm/portager/Chart.yaml
+++ b/helm/portager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: portager
 description: Kubernetes operator for declarative registry-to-registry image sync
 type: application
-version: 0.2.1
-appVersion: "0.2.1"
+version: 0.3.0
+appVersion: "0.3.0"
 maintainers:
   - name: jarodr47

--- a/helm/portager/crds/portager.portager.io_imagesyncs.yaml
+++ b/helm/portager/crds/portager.portager.io_imagesyncs.yaml
@@ -14,7 +14,23 @@ spec:
     singular: imagesync
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Status
+      type: string
+    - jsonPath: .status.syncedImages
+      name: Synced
+      type: integer
+    - jsonPath: .status.failedImages
+      name: Failed
+      type: integer
+    - jsonPath: .spec.schedule
+      name: Schedule
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ImageSync is the Schema for the imagesyncs API
@@ -99,21 +115,34 @@ spec:
                   description: ImageSpec defines a single image to sync, including
                     which tags to copy.
                   properties:
+                    maxTags:
+                      default: 10
+                      description: |-
+                        maxTags limits how many semver-matched tags are synced (newest first).
+                        Only applies when semver is set. 0 means unlimited.
+                      minimum: 0
+                      type: integer
                     name:
                       description: |-
                         name is the image name relative to the source registry
                         (e.g., "go", "node", "python").
                       type: string
+                    semver:
+                      description: |-
+                        semver is a semver constraint string for auto-discovering tags from the
+                        source registry. Supports wildcards (1.x, 1.3.x), ranges (>=1.22.0 <1.23.0),
+                        tilde (~1.3.0), and caret (^1.3.0) syntax. Non-semver tags in the registry
+                        are silently skipped. Resolved tags are sorted by version descending (newest first).
+                      type: string
                     tags:
-                      description: tags is the list of image tags to sync (e.g., ["latest",
-                        "1.22"]).
+                      description: |-
+                        tags is the list of explicit image tags to sync (e.g., ["latest", "1.22"]).
+                        At least one of tags or semver must be specified.
                       items:
                         type: string
-                      minItems: 1
                       type: array
                   required:
                   - name
-                  - tags
                   type: object
                 minItems: 1
                 type: array

--- a/internal/controller/imagesync_controller.go
+++ b/internal/controller/imagesync_controller.go
@@ -46,6 +46,7 @@ import (
 	"github.com/jarodr47/portager/internal/controller/registry"
 	"github.com/jarodr47/portager/internal/controller/schedule"
 	"github.com/jarodr47/portager/internal/controller/sync"
+	"github.com/jarodr47/portager/internal/controller/tags"
 	"github.com/jarodr47/portager/internal/controller/verify"
 )
 
@@ -70,6 +71,10 @@ type ImageSyncReconciler struct {
 	// Validator runs pre-sync validation gates (cosign, vulnerability).
 	// When nil, no validation is performed.
 	Validator *verify.Validator
+
+	// TagResolver resolves semver constraints against registry tags.
+	// When nil, semver filtering is not available.
+	TagResolver *tags.SemverResolver
 }
 
 // +kubebuilder:rbac:groups=portager.portager.io,resources=imagesyncs,verbs=get;list;watch;create;update;patch;delete
@@ -106,6 +111,14 @@ func (r *ImageSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err := r.Scheduler.Validate(imageSync.Spec.Schedule); err != nil {
 		return r.updateStatusWithError(ctx, &imageSync, "InvalidSchedule",
 			fmt.Sprintf("invalid schedule: %v", err))
+	}
+
+	// 2b. Validate that each image has at least one of tags or semver.
+	for _, image := range imageSync.Spec.Images {
+		if len(image.Tags) == 0 && image.Semver == "" {
+			return r.updateStatusWithError(ctx, &imageSync, "InvalidSpec",
+				fmt.Sprintf("image %q must specify at least one of tags or semver", image.Name))
+		}
 	}
 
 	// 3. Check for sync-now annotation (bypasses schedule).
@@ -218,7 +231,29 @@ func (r *ImageSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			Name: image.Name,
 		}
 
-		for _, tag := range image.Tags {
+		// Resolve effective tags: explicit tags + semver-discovered tags.
+		effectiveTags := image.Tags
+		if image.Semver != "" && r.TagResolver != nil {
+			srcRepo := fmt.Sprintf("%s/%s", imageSync.Spec.Source.Registry, image.Name)
+			resolved, err := r.TagResolver.ResolveTags(ctx, srcRepo, image.Semver, image.MaxTags, srcAuthn)
+			if err != nil {
+				failedCount++
+				copyErrors = append(copyErrors, err)
+				log.Error(err, "Failed to resolve semver tags", "image", image.Name, "constraint", image.Semver)
+				r.Recorder.Eventf(&imageSync, corev1.EventTypeWarning, "TagResolutionFailed",
+					"Failed to resolve tags for %s matching %q: %v", image.Name, image.Semver, err)
+				portageMetrics.ImagesFailed.WithLabelValues(imageSync.Name, imageSync.Namespace).Inc()
+				imageResults = append(imageResults, imageStatus)
+				continue
+			}
+			log.Info("Resolved semver tags", "image", image.Name, "constraint", image.Semver,
+				"count", len(resolved), "tags", resolved)
+			r.Recorder.Eventf(&imageSync, corev1.EventTypeNormal, "TagsResolved",
+				"Resolved %d tags for %s matching %q", len(resolved), image.Name, image.Semver)
+			effectiveTags = mergeTags(image.Tags, resolved)
+		}
+
+		for _, tag := range effectiveTags {
 			totalCount++
 			now := metav1.Now()
 
@@ -457,6 +492,26 @@ func buildDestRef(dest portagerv1alpha1.DestinationConfig, imageName, tag string
 		return fmt.Sprintf("%s/%s/%s:%s", dest.Registry, dest.RepositoryPrefix, imageName, tag)
 	}
 	return fmt.Sprintf("%s/%s:%s", dest.Registry, imageName, tag)
+}
+
+// mergeTags combines explicit tags with resolved tags, deduplicating.
+// Explicit tags come first, then resolved tags not already present.
+func mergeTags(explicit, resolved []string) []string {
+	seen := make(map[string]bool, len(explicit))
+	result := make([]string, 0, len(explicit)+len(resolved))
+	for _, t := range explicit {
+		if !seen[t] {
+			seen[t] = true
+			result = append(result, t)
+		}
+	}
+	for _, t := range resolved {
+		if !seen[t] {
+			seen[t] = true
+			result = append(result, t)
+		}
+	}
+	return result
 }
 
 // truncateDigest shortens a digest for display in events.

--- a/internal/controller/imagesync_controller_test.go
+++ b/internal/controller/imagesync_controller_test.go
@@ -36,6 +36,8 @@ import (
 	"github.com/jarodr47/portager/internal/controller/verify"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+
+	"github.com/jarodr47/portager/internal/controller/tags"
 )
 
 // newReconciler creates a reconciler wired with a FakeRecorder and Scheduler.
@@ -83,6 +85,27 @@ func newReconcilerWithValidator(rec *record.FakeRecorder, v *verify.Validator) *
 		Recorder:  rec,
 		Scheduler: schedule.NewScheduler(),
 		Validator: v,
+	}
+}
+
+// mockTagLister implements tags.TagLister for testing.
+type mockTagLister struct {
+	tags []string
+	err  error
+}
+
+func (m *mockTagLister) ListTags(_ context.Context, _ string, _ authn.Authenticator) ([]string, error) {
+	return m.tags, m.err
+}
+
+// newReconcilerWithTagResolver creates a reconciler with a custom TagResolver.
+func newReconcilerWithTagResolver(rec *record.FakeRecorder, resolver *tags.SemverResolver) *ImageSyncReconciler {
+	return &ImageSyncReconciler{
+		Client:      k8sClient,
+		Scheme:      k8sClient.Scheme(),
+		Recorder:    rec,
+		Scheduler:   schedule.NewScheduler(),
+		TagResolver: resolver,
 	}
 }
 
@@ -573,6 +596,192 @@ var _ = Describe("ImageSync Controller", func() {
 			Expect(readyCond).NotTo(BeNil())
 			Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
 			Expect(readyCond.Reason).To(Equal("InvalidSchedule"))
+
+			// Cleanup.
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+	})
+
+	Context("Semver Tag Filtering", func() {
+		ctx := context.Background()
+
+		It("should resolve semver tags and attempt sync for each matched tag", func() {
+			resourceName := "test-semver-resolve"
+			nn := types.NamespacedName{Name: resourceName, Namespace: "default"}
+
+			resource := &portagerv1alpha1.ImageSync{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: portagerv1alpha1.ImageSyncSpec{
+					Schedule: "@every 1h",
+					Source:   portagerv1alpha1.SourceConfig{Registry: "fake-registry.invalid"},
+					Destination: portagerv1alpha1.DestinationConfig{
+						Registry: "localhost:5000",
+						Auth:     portagerv1alpha1.AuthConfig{Method: "anonymous"},
+					},
+					Images: []portagerv1alpha1.ImageSpec{
+						{
+							Name:   "alpine",
+							Semver: "1.x",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			fakeRecorder := record.NewFakeRecorder(100)
+			lister := &mockTagLister{tags: []string{"1.0", "1.1", "1.2", "2.0", "latest"}}
+			resolver := &tags.SemverResolver{Lister: lister}
+			reconciler := newReconcilerWithTagResolver(fakeRecorder, resolver)
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			// Fake registry fails at digest — but sync was attempted for resolved tags.
+			Expect(err).To(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, nn, resource)).To(Succeed())
+
+			// Should have resolved 3 tags (1.2, 1.1, 1.0) matching 1.x.
+			Expect(resource.Status.Images).To(HaveLen(1))
+			Expect(resource.Status.Images[0].Tags).To(HaveLen(3))
+			Expect(resource.Status.TotalImages).To(Equal(3))
+
+			// Verify TagsResolved event was emitted.
+			Expect(fakeRecorder.Events).To(Receive(ContainSubstring("TagsResolved")))
+
+			// Cleanup.
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+
+		It("should merge explicit tags with semver-resolved tags", func() {
+			resourceName := "test-semver-merge"
+			nn := types.NamespacedName{Name: resourceName, Namespace: "default"}
+
+			resource := &portagerv1alpha1.ImageSync{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: portagerv1alpha1.ImageSyncSpec{
+					Schedule: "@every 1h",
+					Source:   portagerv1alpha1.SourceConfig{Registry: "fake-registry.invalid"},
+					Destination: portagerv1alpha1.DestinationConfig{
+						Registry: "localhost:5000",
+						Auth:     portagerv1alpha1.AuthConfig{Method: "anonymous"},
+					},
+					Images: []portagerv1alpha1.ImageSpec{
+						{
+							Name:   "alpine",
+							Tags:   []string{"latest", "1.2"},
+							Semver: "1.x",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			fakeRecorder := record.NewFakeRecorder(100)
+			// Semver resolves 1.2, 1.1, 1.0 — but 1.2 is already in explicit tags.
+			lister := &mockTagLister{tags: []string{"1.0", "1.1", "1.2", "2.0"}}
+			resolver := &tags.SemverResolver{Lister: lister}
+			reconciler := newReconcilerWithTagResolver(fakeRecorder, resolver)
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			Expect(err).To(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, nn, resource)).To(Succeed())
+
+			// Explicit: [latest, 1.2] + Resolved: [1.2, 1.1, 1.0] → Merged: [latest, 1.2, 1.1, 1.0]
+			Expect(resource.Status.Images[0].Tags).To(HaveLen(4))
+			Expect(resource.Status.TotalImages).To(Equal(4))
+
+			// Cleanup.
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+
+		It("should reject ImageSync with neither tags nor semver", func() {
+			resourceName := "test-semver-no-tags"
+			nn := types.NamespacedName{Name: resourceName, Namespace: "default"}
+
+			resource := &portagerv1alpha1.ImageSync{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: portagerv1alpha1.ImageSyncSpec{
+					Schedule: "@every 1h",
+					Source:   portagerv1alpha1.SourceConfig{Registry: "fake-registry.invalid"},
+					Destination: portagerv1alpha1.DestinationConfig{
+						Registry: "localhost:5000",
+						Auth:     portagerv1alpha1.AuthConfig{Method: "anonymous"},
+					},
+					Images: []portagerv1alpha1.ImageSpec{
+						{Name: "alpine"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			fakeRecorder := record.NewFakeRecorder(100)
+			reconciler := newReconciler(fakeRecorder)
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("InvalidSpec"))
+
+			// Verify Ready condition is False with InvalidSpec reason.
+			Expect(k8sClient.Get(ctx, nn, resource)).To(Succeed())
+			readyCond := meta.FindStatusCondition(resource.Status.Conditions, "Ready")
+			Expect(readyCond).NotTo(BeNil())
+			Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(readyCond.Reason).To(Equal("InvalidSpec"))
+
+			// Cleanup.
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+
+		It("should handle tag resolution failure gracefully", func() {
+			resourceName := "test-semver-fail"
+			nn := types.NamespacedName{Name: resourceName, Namespace: "default"}
+
+			resource := &portagerv1alpha1.ImageSync{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: portagerv1alpha1.ImageSyncSpec{
+					Schedule: "@every 1h",
+					Source:   portagerv1alpha1.SourceConfig{Registry: "fake-registry.invalid"},
+					Destination: portagerv1alpha1.DestinationConfig{
+						Registry: "localhost:5000",
+						Auth:     portagerv1alpha1.AuthConfig{Method: "anonymous"},
+					},
+					Images: []portagerv1alpha1.ImageSpec{
+						{
+							Name:   "alpine",
+							Semver: "1.x",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			fakeRecorder := record.NewFakeRecorder(100)
+			lister := &mockTagLister{err: fmt.Errorf("registry timeout")}
+			resolver := &tags.SemverResolver{Lister: lister}
+			reconciler := newReconcilerWithTagResolver(fakeRecorder, resolver)
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			Expect(err).To(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, nn, resource)).To(Succeed())
+
+			// Image should show as failed due to tag resolution error.
+			Expect(resource.Status.FailedImages).To(Equal(1))
+
+			// Verify TagResolutionFailed event was emitted.
+			Expect(fakeRecorder.Events).To(Receive(ContainSubstring("TagResolutionFailed")))
 
 			// Cleanup.
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())

--- a/internal/controller/tags/resolver.go
+++ b/internal/controller/tags/resolver.go
@@ -1,0 +1,102 @@
+package tags
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/crane"
+)
+
+// TagLister lists all tags for a repository from a registry.
+type TagLister interface {
+	ListTags(ctx context.Context, repository string, auth authn.Authenticator) ([]string, error)
+}
+
+// CraneTagLister implements TagLister using crane.ListTags.
+type CraneTagLister struct{}
+
+// ListTags lists all tags for a repository using the Docker Registry V2 API.
+func (c *CraneTagLister) ListTags(ctx context.Context, repository string, auth authn.Authenticator) ([]string, error) {
+	opts := []crane.Option{
+		crane.WithContext(ctx),
+		crane.WithAuth(auth),
+	}
+	if isInsecureRegistry(repository) {
+		opts = append(opts, crane.Insecure)
+	}
+
+	tags, err := crane.ListTags(repository, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("listing tags for %s: %w", repository, err)
+	}
+	return tags, nil
+}
+
+// tagVersion pairs the original tag string with its parsed semver version.
+type tagVersion struct {
+	original string
+	version  *semver.Version
+}
+
+// SemverResolver resolves semver constraints against registry tags.
+type SemverResolver struct {
+	Lister TagLister
+}
+
+// ResolveTags lists tags from the registry, filters by the semver constraint,
+// sorts descending (newest first), and truncates to maxTags.
+// Returns the original tag strings (not coerced versions).
+func (r *SemverResolver) ResolveTags(ctx context.Context, repository string, constraint string, maxTags int, auth authn.Authenticator) ([]string, error) {
+	// Parse the constraint first to fail fast on invalid input.
+	c, err := semver.NewConstraint(constraint)
+	if err != nil {
+		return nil, fmt.Errorf("invalid semver constraint %q: %w", constraint, err)
+	}
+
+	// List all tags from the registry.
+	allTags, err := r.Lister.ListTags(ctx, repository, auth)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse each tag as semver, filter by constraint.
+	var matched []tagVersion
+	for _, tag := range allTags {
+		v, err := semver.NewVersion(tag)
+		if err != nil {
+			// Not a valid semver tag (e.g., "latest", "alpine") — skip silently.
+			continue
+		}
+		if c.Check(v) {
+			matched = append(matched, tagVersion{original: tag, version: v})
+		}
+	}
+
+	// Sort by semver descending (newest first).
+	sort.Slice(matched, func(i, j int) bool {
+		return matched[i].version.GreaterThan(matched[j].version)
+	})
+
+	// Truncate to maxTags if set.
+	if maxTags > 0 && len(matched) > maxTags {
+		matched = matched[:maxTags]
+	}
+
+	// Extract original tag strings.
+	result := make([]string, len(matched))
+	for i, tv := range matched {
+		result[i] = tv.original
+	}
+	return result, nil
+}
+
+// isInsecureRegistry returns true for registries that use HTTP (not HTTPS).
+func isInsecureRegistry(ref string) bool {
+	return strings.HasPrefix(ref, "localhost") ||
+		strings.HasPrefix(ref, "localhost:") ||
+		strings.HasPrefix(ref, "127.0.0.1")
+}

--- a/internal/controller/tags/resolver_test.go
+++ b/internal/controller/tags/resolver_test.go
@@ -1,0 +1,164 @@
+package tags
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTags(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Tags Suite")
+}
+
+// mockTagLister returns a fixed set of tags or an error.
+type mockTagLister struct {
+	tags []string
+	err  error
+}
+
+func (m *mockTagLister) ListTags(_ context.Context, _ string, _ authn.Authenticator) ([]string, error) {
+	return m.tags, m.err
+}
+
+var _ = Describe("SemverResolver", func() {
+	var (
+		ctx      context.Context
+		resolver *SemverResolver
+		lister   *mockTagLister
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		lister = &mockTagLister{}
+		resolver = &SemverResolver{Lister: lister}
+	})
+
+	Describe("ResolveTags", func() {
+		Context("wildcard constraints", func() {
+			It("should match 1.x against matching tags", func() {
+				lister.tags = []string{"1.0", "1.1", "1.2", "2.0", "latest"}
+				tags, err := resolver.ResolveTags(ctx, "docker.io/library/alpine", "1.x", 10, authn.Anonymous)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tags).To(Equal([]string{"1.2", "1.1", "1.0"}))
+			})
+
+			It("should match 1.3.x against patch versions", func() {
+				lister.tags = []string{"1.2.9", "1.3.0", "1.3.1", "1.3.2", "1.4.0"}
+				tags, err := resolver.ResolveTags(ctx, "docker.io/library/node", "1.3.x", 10, authn.Anonymous)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tags).To(Equal([]string{"1.3.2", "1.3.1", "1.3.0"}))
+			})
+		})
+
+		Context("range constraints", func() {
+			It("should match >= < range", func() {
+				lister.tags = []string{"1.21.5", "1.22.0", "1.22.1", "1.23.0"}
+				tags, err := resolver.ResolveTags(ctx, "docker.io/library/go", ">= 1.22.0, < 1.23.0", 10, authn.Anonymous)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tags).To(Equal([]string{"1.22.1", "1.22.0"}))
+			})
+
+			It("should match tilde range ~1.3.0", func() {
+				lister.tags = []string{"1.2.9", "1.3.0", "1.3.5", "1.4.0"}
+				tags, err := resolver.ResolveTags(ctx, "docker.io/library/node", "~1.3.0", 10, authn.Anonymous)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tags).To(Equal([]string{"1.3.5", "1.3.0"}))
+			})
+
+			It("should match caret range ^1.3.0", func() {
+				lister.tags = []string{"1.2.9", "1.3.0", "1.5.0", "1.99.0", "2.0.0"}
+				tags, err := resolver.ResolveTags(ctx, "docker.io/library/node", "^1.3.0", 10, authn.Anonymous)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tags).To(Equal([]string{"1.99.0", "1.5.0", "1.3.0"}))
+			})
+		})
+
+		Context("maxTags truncation", func() {
+			It("should truncate to maxTags newest versions", func() {
+				lister.tags = []string{"1.0", "1.1", "1.2", "1.3", "1.4"}
+				tags, err := resolver.ResolveTags(ctx, "repo", "1.x", 2, authn.Anonymous)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tags).To(Equal([]string{"1.4", "1.3"}))
+			})
+
+			It("should return all when maxTags is 0 (unlimited)", func() {
+				lister.tags = []string{"1.0", "1.1", "1.2", "1.3", "1.4"}
+				tags, err := resolver.ResolveTags(ctx, "repo", "1.x", 0, authn.Anonymous)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tags).To(HaveLen(5))
+			})
+		})
+
+		Context("non-semver tags", func() {
+			It("should silently skip non-semver tags", func() {
+				lister.tags = []string{"latest", "alpine", "1.0", "bullseye", "1.1"}
+				tags, err := resolver.ResolveTags(ctx, "repo", "1.x", 10, authn.Anonymous)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tags).To(Equal([]string{"1.1", "1.0"}))
+			})
+
+			It("should skip tags with non-semver suffixes", func() {
+				lister.tags = []string{"1.22-alpine", "1.22.0", "1.22.1-rc.1", "1.22.1"}
+				tags, err := resolver.ResolveTags(ctx, "repo", "~1.22.0", 10, authn.Anonymous)
+				Expect(err).NotTo(HaveOccurred())
+				// Pre-release versions like 1.22.1-rc.1 are valid semver but won't match
+				// constraints by default in Masterminds/semver (pre-releases only match
+				// if the constraint itself includes a pre-release).
+				// 1.22-alpine is not valid semver (skipped).
+				Expect(tags).To(Equal([]string{"1.22.1", "1.22.0"}))
+			})
+		})
+
+		Context("error cases", func() {
+			It("should return error for invalid constraint", func() {
+				lister.tags = []string{"1.0"}
+				_, err := resolver.ResolveTags(ctx, "repo", "not a valid constraint!!!", 10, authn.Anonymous)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid semver constraint"))
+			})
+
+			It("should propagate ListTags error", func() {
+				lister.err = fmt.Errorf("registry unavailable")
+				_, err := resolver.ResolveTags(ctx, "repo", "1.x", 10, authn.Anonymous)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("registry unavailable"))
+			})
+		})
+
+		Context("edge cases", func() {
+			It("should return empty slice when no tags match", func() {
+				lister.tags = []string{"2.0", "3.0", "latest"}
+				tags, err := resolver.ResolveTags(ctx, "repo", "1.x", 10, authn.Anonymous)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tags).To(BeEmpty())
+			})
+
+			It("should return empty slice when registry has no tags", func() {
+				lister.tags = []string{}
+				tags, err := resolver.ResolveTags(ctx, "repo", "1.x", 10, authn.Anonymous)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tags).To(BeEmpty())
+			})
+
+			It("should preserve original tag strings (not coerced versions)", func() {
+				// "1.22" is coerced to "1.22.0" for matching, but returned as "1.22"
+				lister.tags = []string{"1.22", "1.23"}
+				tags, err := resolver.ResolveTags(ctx, "repo", "1.x", 10, authn.Anonymous)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tags).To(Equal([]string{"1.23", "1.22"}))
+			})
+
+			It("should handle v-prefixed tags", func() {
+				lister.tags = []string{"v1.0.0", "v1.1.0", "v2.0.0"}
+				tags, err := resolver.ResolveTags(ctx, "repo", "1.x", 10, authn.Anonymous)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tags).To(Equal([]string{"v1.1.0", "v1.0.0"}))
+			})
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- Add semver constraint support for auto-discovering tags from source registries (semver and maxTags fields on ImageSpec), resolving issue #18
- Add kubectl print columns so kubectl get imagesync shows Status, Synced, Failed, Schedule, and Age
- Update docs (CONFIGURATION.md, DEPLOY_README.md, README.md) with semver examples and pre-sync validation features

## Details
Users can now specify semver constraints instead of listing every tag explicitly:
```yaml
images:
  - name: alpine
    semver: "3.21.x"        # auto-sync newest 3.21.x patch releases
    maxTags: 10              # default: 10 newest matches
  - name: go
    tags: ["latest"]         # explicit + semver can be combined
    semver: "~1.22.0"
```
Supports wildcards (1.x), ranges (>=1.22.0 <1.23.0), tilde (~1.3.0), and caret (^1.3.0) syntax via Masterminds/semver/v3. Non-semver tags are silently skipped. Original tag strings are preserved (registry 1.22 stays 1.22, not coerced to 1.22.0).

Closes #18 