### PR TITLE
Custom CA certificates for private registries

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -40,6 +40,13 @@ For deployment walkthroughs, see the [Deploy Guide](DEPLOY_README.md). For a pro
 | `extraEnv` | `[]` | Additional environment variables for the controller container |
 | `extraVolumes` | `[]` | Additional volumes for the controller pod |
 | `extraVolumeMounts` | `[]` | Additional volume mounts for the controller container |
+| `caBundle.enabled` | `false` | Trust a custom CA for registries with internally-signed certificates |
+| `caBundle.existingSecret` | `""` | Name of an existing Secret holding the PEM bundle |
+| `caBundle.existingConfigMap` | `""` | Name of an existing ConfigMap holding the PEM bundle (e.g. a trust-manager Bundle target) |
+| `caBundle.inline` | `""` | Inline PEM bundle; the chart creates a ConfigMap from it |
+| `caBundle.key` | `ca.crt` | Key within the Secret/ConfigMap holding the PEM bundle |
+| `caBundle.mountPath` | `/etc/portager/ca` | Where the bundle is mounted in the controller |
+| `caBundle.mode` | `append` | `append` trusts the CA in addition to public roots; `replace` trusts only this CA |
 | `podDisruptionBudget.enabled` | `false` | Enable PodDisruptionBudget for the controller |
 | `podDisruptionBudget.minAvailable` | `1` | Minimum available pods during disruption |
 | `startupProbe.enabled` | `false` | Enable startup probe (httpGet /healthz:8081, 5min budget) |
@@ -208,6 +215,78 @@ helm install portager oci://ghcr.io/jarodr47/portager/charts/portager \
   --set extraVolumeMounts[0].mountPath=/var/secrets/google \
   --set extraVolumeMounts[0].readOnly=true
 ```
+
+---
+
+## Custom CA Certificates
+
+If your registry presents a certificate signed by an internal CA — common in air-gapped, federal, and
+enterprise environments — Portager will fail with `x509: certificate signed by unknown authority` until
+that CA is trusted.
+
+The `caBundle` values mount a PEM bundle into the controller and point Go's trust store at it. This
+covers **every** outbound connection: registries, AWS STS/ECR, Google token endpoints, and the Sigstore
+TUF/Fulcio/Rekor endpoints used by keyless cosign verification.
+
+### From an existing ConfigMap (recommended)
+
+CA certificates are public data, so a ConfigMap is the natural home. If you use
+[trust-manager](https://cert-manager.io/docs/trust/trust-manager/), your org bundle is already
+distributed as one:
+
+```bash
+helm install portager oci://ghcr.io/jarodr47/portager/charts/portager \
+  -n portager-system --create-namespace \
+  --set caBundle.enabled=true \
+  --set caBundle.existingConfigMap=org-ca-bundle
+```
+
+### From an existing Secret
+
+```bash
+kubectl create configmap org-ca-bundle -n portager-system --from-file=ca.crt=/path/to/ca.crt
+# or, if the bundle must live in a Secret:
+kubectl create secret generic org-ca-bundle -n portager-system --from-file=ca.crt=/path/to/ca.crt
+
+helm install portager oci://ghcr.io/jarodr47/portager/charts/portager \
+  -n portager-system --create-namespace \
+  --set caBundle.enabled=true \
+  --set caBundle.existingSecret=org-ca-bundle
+```
+
+The object must live in the same namespace as the controller. Only `caBundle.key` (default `ca.crt`) is
+projected into the mount, so other keys in the object are ignored.
+
+### Trust modes
+
+| Mode | Behavior | Use when |
+|------|----------|----------|
+| `append` (default) | Trusts your CA **in addition to** the public roots | Mixed environments — mirroring from Docker Hub or GHCR into an internal registry |
+| `replace` | Trusts **only** your CA | Fully air-gapped, where reaching a public registry should be impossible by construction |
+
+`replace` will break public registries and public Sigstore verification. That is the point of it — it
+makes "this operator can only talk to our infrastructure" a property of the deployment rather than a
+policy anyone has to enforce.
+
+### Rotation requires a pod restart
+
+Go builds its trust store once at process start, so replacing the CA in a Secret or ConfigMap does not
+affect a running controller. Restart it:
+
+```bash
+kubectl rollout restart deploy/portager-controller-manager -n portager-system
+```
+
+When you use `caBundle.inline`, the chart adds a `checksum/ca-bundle` pod annotation so `helm upgrade`
+rolls the pods for you.
+
+> **Warning: do not set `AWS_CA_BUNDLE` for this.** Unlike `SSL_CERT_DIR`, the AWS SDK's `AWS_CA_BUNDLE`
+> **replaces** the trust store rather than adding to it, so pointing it at only your internal CA breaks
+> STS and ECR against real AWS endpoints. `caBundle` already covers AWS traffic.
+
+> **Note on keyless cosign.** Verification against a **private** Fulcio/Rekor also needs the Sigstore
+> client pointed at your instance (`TUF_MIRROR` and related `SIGSTORE_*` variables via `extraEnv`).
+> `caBundle` makes the TLS handshake succeed; it does not redirect which Sigstore instance is used.
 
 ---
 

--- a/helm/portager/templates/_helpers.tpl
+++ b/helm/portager/templates/_helpers.tpl
@@ -65,3 +65,54 @@ Container image reference.
 {{- $tag := .Values.image.tag | default .Chart.AppVersion }}
 {{- printf "%s:%s" .Values.image.repository $tag }}
 {{- end }}
+
+{{/*
+Fail fast on an ambiguous or incomplete caBundle configuration. Rendering a
+Deployment that silently ignores a misconfigured CA is far worse than refusing
+to render, because the failure would otherwise surface as an x509 error at the
+first sync, long after install.
+*/}}
+{{- define "portager.caBundle.validate" -}}
+{{- if .Values.caBundle.enabled -}}
+{{- $sources := list -}}
+{{- if .Values.caBundle.existingSecret }}{{- $sources = append $sources "existingSecret" -}}{{- end -}}
+{{- if .Values.caBundle.existingConfigMap }}{{- $sources = append $sources "existingConfigMap" -}}{{- end -}}
+{{- if .Values.caBundle.inline }}{{- $sources = append $sources "inline" -}}{{- end -}}
+{{- if eq (len $sources) 0 -}}
+{{- fail "caBundle.enabled is true but no source is set. Set exactly one of caBundle.existingSecret, caBundle.existingConfigMap, or caBundle.inline." -}}
+{{- end -}}
+{{- if gt (len $sources) 1 -}}
+{{- fail (printf "caBundle accepts exactly one source, but %d were set: %s" (len $sources) (join ", " $sources)) -}}
+{{- end -}}
+{{- if not (has .Values.caBundle.mode (list "append" "replace")) -}}
+{{- fail (printf "caBundle.mode must be \"append\" or \"replace\", got %q" (toString .Values.caBundle.mode)) -}}
+{{- end -}}
+{{- if not .Values.caBundle.key -}}
+{{- fail "caBundle.key must not be empty." -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+The CA bundle volume. Only the configured key is projected, so unrelated keys in
+the source object (a tls.key alongside tls.crt, for instance) never land in the
+certificate directory where Go would try to parse them.
+*/}}
+{{- define "portager.caBundle.volume" -}}
+- name: ca-bundle
+  {{- if .Values.caBundle.existingSecret }}
+  secret:
+    secretName: {{ .Values.caBundle.existingSecret }}
+    defaultMode: 0444
+    items:
+      - key: {{ .Values.caBundle.key }}
+        path: {{ .Values.caBundle.key }}
+  {{- else }}
+  configMap:
+    name: {{ if .Values.caBundle.existingConfigMap }}{{ .Values.caBundle.existingConfigMap }}{{ else }}{{ include "portager.fullname" . }}-ca-bundle{{ end }}
+    defaultMode: 0444
+    items:
+      - key: {{ .Values.caBundle.key }}
+        path: {{ .Values.caBundle.key }}
+  {{- end }}
+{{- end }}

--- a/helm/portager/templates/configmap-ca.yaml
+++ b/helm/portager/templates/configmap-ca.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.caBundle.enabled .Values.caBundle.inline }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "portager.fullname" . }}-ca-bundle
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "portager.labels" . | nindent 4 }}
+data:
+  {{ .Values.caBundle.key }}: |
+    {{- .Values.caBundle.inline | nindent 4 }}
+{{- end }}

--- a/helm/portager/templates/deployment.yaml
+++ b/helm/portager/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "portager.caBundle.validate" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -12,9 +13,16 @@ spec:
       {{- include "portager.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- $caChecksum := and .Values.caBundle.enabled .Values.caBundle.inline }}
+      {{- if or .Values.podAnnotations $caChecksum }}
       annotations:
+        {{- if $caChecksum }}
+        # Go loads its trust store once at startup, so a changed CA needs a new pod.
+        checksum/ca-bundle: {{ .Values.caBundle.inline | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "portager.selectorLabels" . | nindent 8 }}
@@ -67,6 +75,23 @@ spec:
           env:
             - name: TUF_ROOT
               value: /tmp/.sigstore
+            {{- if .Values.caBundle.enabled }}
+            {{- if eq .Values.caBundle.mode "replace" }}
+            # Trust ONLY the supplied CA. SSL_CERT_FILE replaces the default file
+            # list and SSL_CERT_DIR the default directory list; setting both is
+            # what excludes the system roots entirely.
+            - name: SSL_CERT_FILE
+              value: {{ printf "%s/%s" .Values.caBundle.mountPath .Values.caBundle.key | quote }}
+            - name: SSL_CERT_DIR
+              value: {{ .Values.caBundle.mountPath | quote }}
+            {{- else }}
+            # Go unions the certificates found across every directory in
+            # SSL_CERT_DIR, so listing the system path alongside ours appends
+            # the private CA to the public roots rather than replacing them.
+            - name: SSL_CERT_DIR
+              value: {{ printf "/etc/ssl/certs:%s" .Values.caBundle.mountPath | quote }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.aws.credentials.enabled }}
             - name: AWS_ACCESS_KEY_ID
               value: {{ .Values.aws.credentials.accessKeyId | quote }}
@@ -109,6 +134,11 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- if .Values.caBundle.enabled }}
+            - name: ca-bundle
+              mountPath: {{ .Values.caBundle.mountPath | quote }}
+              readOnly: true
+            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -116,6 +146,9 @@ spec:
         - name: tmp
           emptyDir:
             medium: Memory
+        {{- if .Values.caBundle.enabled }}
+        {{- include "portager.caBundle.volume" . | nindent 8 }}
+        {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/portager/values.yaml
+++ b/helm/portager/values.yaml
@@ -96,6 +96,45 @@ extraVolumeMounts: []
   # - name: tmp
   #   mountPath: /tmp
 
+# -- Custom CA certificates for private registries
+#
+# Mounts a PEM-encoded CA bundle into the controller and points Go's trust store
+# at it, so Portager can talk to registries whose certificates are signed by an
+# internal CA. Applies to every outbound connection — registries, AWS STS/ECR,
+# Google token endpoints, and the Sigstore TUF/Fulcio/Rekor endpoints used by
+# keyless cosign verification.
+#
+# Note: Go builds its trust store once at startup, so rotating the CA requires a
+# pod restart. When `inline` is used the chart adds a checksum annotation that
+# rolls the pods automatically.
+
+caBundle:
+  enabled: false
+
+  # Exactly one source must be set when enabled.
+  # existingSecret / existingConfigMap reference an object you already manage —
+  # for example a trust-manager Bundle target, which is a ConfigMap.
+  existingSecret: ""
+  existingConfigMap: ""
+  # inline creates a ConfigMap from a PEM string supplied here.
+  inline: ""
+  #   inline: |
+  #     -----BEGIN CERTIFICATE-----
+  #     ...
+  #     -----END CERTIFICATE-----
+
+  # Key within the Secret/ConfigMap holding the PEM bundle. The default matches
+  # cert-manager Certificate Secrets, trust-manager Bundles, and kube-root-ca.crt.
+  key: ca.crt
+
+  mountPath: /etc/portager/ca
+
+  # append  — trust this CA IN ADDITION to the public roots. Safe default; keeps
+  #           Docker Hub, GHCR, ECR and friends working.
+  # replace — trust ONLY this CA. Public registries and public Sigstore endpoints
+  #           will stop working. Intended for fully air-gapped installs.
+  mode: append
+
 # -- Disruption and probes
 
 podDisruptionBudget:


### PR DESCRIPTION
Closes #60 

## Custom CA certificates for private registries

Closes #60. First item of #69.

Registries signed by an internal CA fail today with
`x509: certificate signed by unknown authority`, with no workaround. This
blocks air-gapped, federal, and enterprise users.

### How it works

A new `caBundle` block mounts a PEM bundle and points Go's trust store at it.
Trust is applied at the **process** level, not per-connection, so every
outbound TLS connection picks it up with **no Go changes**.

```bash
kubectl create configmap org-ca -n portager-system --from-file=ca.crt=ca.crt

helm install portager oci://ghcr.io/jarodr47/portager/charts/portager \
  -n portager-system --create-namespace \
  --set caBundle.enabled=true \
  --set caBundle.existingConfigMap=my-custom-ca
```

Every ImageSync trusts it, no per-resource configuration.

### Sources and modes
Three sources: `existingSecret`, `existingConfigMap` (e.g. a trust-manager
Bundle target), or inline, which creates a ConfigMap from a PEM string.